### PR TITLE
Create harvestOpenarchCIV.py

### DIFF
--- a/scripts/openarch/harvestOpenarchCIV.py
+++ b/scripts/openarch/harvestOpenarchCIV.py
@@ -1,0 +1,37 @@
+#! /usr/bin/env python3
+# Python3 harvest OpenArch in N-triples / CIV ontology
+
+import requests
+import csv
+import time
+
+def resolveURI(uri, requestformat = "application/n-triples+civ"):
+
+    headers = {"Accept": requestformat }
+
+    try:
+        r = requests.get(uri, headers = headers)
+    except:
+        print("Request error") 
+
+    return r.text
+
+
+def harvestOpenarch(filename,timestr):
+
+    CSVfilename = filename + ".csv"
+    outfile = open('harvested/openarch-'+timestr+'.nt','a')
+
+    with open(CSVfilename, newline='') as infile:
+        reader = csv.DictReader(infile)
+        for row in reader:
+            uri = row['URL'].strip()
+            identifier = uri.replace("https://www.openarch.nl/","")
+            print(identifier) # progress indicator/debugging
+            outfile.write(resolveURI(uri))
+
+timestr=time.strftime("%Y%m%d-%H%M%S")
+harvestOpenarch("huwelijksaktes",timestr)
+harvestOpenarch("overlijdensaktes",timestr)
+harvestOpenarch("geboorteaktes",timestr)
+print('harvest/openarch-'+timestr+'.nt created')


### PR DESCRIPTION
Open Archives is able to deliver N-triples (and Turtle) in CIV ontology including data standardisation of names (eg. curl  -H 'Accept: application/n-triples+civ' https://www.openarch.nl/hga:F6619DCA-BE62-4A37-B09D-960CB8900393). This Python script harvests all aktes and writes all N-triples to one file in the harvested directory.